### PR TITLE
Streamingで流れた unlisted tootは凍結後削除されるように

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -66,7 +66,7 @@ class BatchedRemoveStatusService < BaseService
   end
 
   def unpush_from_public_timelines(status)
-    return unless status.public_visibility?
+    return unless status.wakuwaku_visibility?
 
     payload = @json_payloads[status.id]
 


### PR DESCRIPTION
テストが終了したら Draft を解除するつもりです

現象
1. `RUN_STREAMING=true foreman start`
2. adminアカウントで LTL を開く
3. (一般ユーザーuser を作成して) userアカウントで unlisted toot と public toot を投稿
4. adminアカウントで LTL がStreaming により更新されたことを確認
5. adminアカウントで user アカウントを凍結
6. adminアカウントで LTL がuser アカウントのpublic toot のみ消え unlisted toot は消去されない